### PR TITLE
Fix RMSE calculation to use test_data

### DIFF
--- a/book1/chapters/ch07-prediction/model_develop_and_eval.R
+++ b/book1/chapters/ch07-prediction/model_develop_and_eval.R
@@ -115,7 +115,7 @@ get_regression_evaluation_measures <- function(model, train_ds, test_data) {
   R2 <- 1 - RSS/TSS
   
   #RMSE = sqrt(RSS/N)
-  RMSE <- sqrt(RSS/nrow(test_ds))
+  RMSE <- sqrt(RSS/nrow(test_data))
   
   #MAE = avg(abs(predicted - actual))
   MAE <- mean(abs(predicted_vals - actual_vals))


### PR DESCRIPTION
Not exactly a bug, but it's better to use the parameter than to rely on the global environment variable.